### PR TITLE
Remove repeated props in weatherIcons

### DIFF
--- a/app/components/Weather.js
+++ b/app/components/Weather.js
@@ -4,23 +4,25 @@ import {useSpring, animated, useTransition} from 'react-spring';
 import {Transition} from 'react-spring/renderprops';
 
 var weatherIcons = {
-  1: <WiAlien color="rgb(140, 22, 134)" size={300}/>,
-  2: <WiThunderstorm color="rgb(140, 22, 134)" size={300}/>,
-  3: <WiRaindrops color="rgb(140, 22, 134)" size={300}/>,
-  4: <WiAlien color="rgb(140, 22, 134)" size={300}/>,
-  5: <WiRain color="rgb(140, 22, 134)" size={300}/>,
-  6: <WiSnow color="rgb(140, 22, 134)" size={300}/> ,
-  7: <WiFog color="rgb(140, 22, 134)" size={300}/>,
-  8: <WiDaySunny color="rgb(140, 22, 134)" size={300}/>,
+  1: WiAlien,
+  2: WiThunderstorm,
+  3: WiRaindrops,
+  4: WiAlien,
+  5: WiRain,
+  6: WiSnow,
+  7: WiFog,
+  8: WiDaySunny,
 }
 
 
 
 
 export default function Weather(props){
+  const WeatherIcon = weatherIcons[props.id];
+
   return (
       <React.Fragment>
-        {weatherIcons[props.id]}
+        <WeatherIcon size={300} color="rgb(140, 22, 134)" />
       </React.Fragment>
     );
 


### PR DESCRIPTION
Remove hardcoded components and repeated props in each `weatherIcons` value in favor of setting the component and adding the props during render.